### PR TITLE
fix axes metadata for points/shapes

### DIFF
--- a/R/CTutils.R
+++ b/R/CTutils.R
@@ -59,7 +59,12 @@ setMethod("axes", "SpatialDataAttrs", \(x, y=NULL, ...) {
     if (is.null(x)) stop("couldn't find 'axes'") 
     if (is.null(y)) return(x)
     y <- match.arg(y, c("name", "type", "unit"))
-    vapply(x, `[[`, character(1), y)
+    # shape/point axes have no type and unit, return axes names as given
+    if(y == "name" && is.null(names(x[[1]]))){
+      unlist(x)
+    } else {
+      vapply(x, `[[`, character(1), y)
+    }
 })
 
 # CTlist/data/type/name() ----

--- a/R/crop.R
+++ b/R/crop.R
@@ -141,9 +141,9 @@ NULL
         ct[[type]] <- .adapt(data, type)
     }
     # update input axes from 'cyx' to 'xy'
-    ct$input$axes <- .default_ax(type="frame")
+    ct$input$axes <- .default_ax(type="shape")
     # create temporary shape & transform back
-    md <- SpatialDataAttrs(type="frame", trans=list(ct))
+    md <- SpatialDataAttrs(type="shape", trans=list(ct))
     z <- SpatialDataShape(df, meta=md)
     z <- transform(z, 1, rev=TRUE)
     # extract coordinates & return range

--- a/R/crop.R
+++ b/R/crop.R
@@ -142,6 +142,7 @@ NULL
     }
     # update input axes from 'cyx' to 'xy'
     ct$input$axes <- .default_ax(type="shape")
+    ct$input$name <- "xy"
     # create temporary shape & transform back
     md <- SpatialDataAttrs(type="shape", trans=list(ct))
     z <- SpatialDataShape(df, meta=md)

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -19,7 +19,8 @@
 #' @param dim scalar integer in 2-4 when \code{type} is either "image" or 
 #'   "label", and 2-3 when "shape" or "point";
 #'   number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time) for image and 
-#'   label; when \code{type="image"}).
+#'   label; when \code{type="image"}, C (channel) will be added (for any 
+#'   \code{dim}).
 #' @param nch scalar integer; how many channels should there be?
 #'   (ignored if \code{type="label"}, \code{type="shape"}, or 
 #'   \code{type="point"}). 

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -146,7 +146,7 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
   if (is.character(ax[[1]])) {
     unlist(ax)
   } else {
-    lapply(ax, \(.) .$name)
+    vapply(ax, \(.) .$name, character(1))
   }
 }
 
@@ -170,7 +170,7 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
       coordinateTransformations = list(
         list(
           scale = lapply(
-            unlist(axes),
+            axes,
             \(.) if(. == "c") 1 else s),
           type = "scale"
         )

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -102,7 +102,10 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
         if (ver == "0.3") res <- list(ome=res)
     } else {
         # points/shapes
-        res <- list(axes=ax, coordinateTransformations=ct)
+        res <- list(
+          axes=.ax_names(ax), # point and shape take only names
+          coordinateTransformations=ct
+        )
     }
     res$spatialdata_attrs <- list(version=ver)
     SpatialDataAttrs(res)
@@ -120,9 +123,9 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
         # xyzt for points/shapes
         point=,
         shape={
-            ax <- list(x$name, y$name)
+            ax <- list(x, y)
             if (dim > 2) {
-                ax <- c(ax, list(z$name))
+                ax <- c(ax, list(z))
             }
         },
         # tczyx for images/labels
@@ -143,13 +146,17 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
   if (is.character(ax[[1]])) {
     unlist(ax)
   } else {
-    vapply(ax, \(.) .$name, character(1))
+    lapply(ax, \(.) .$name)
   }
 }
 
 # Internal helper to generate coordinate transformations
 .default_ct <- \(axes, name="global", type="identity", data=NULL) {
-    ct <- list(input=axes, output=list(name=name), type=type)
+    ct <- list(input=list(axes=axes, 
+                          name=paste(.ax_names(axes), collapse = "")), 
+               output=list(axes=axes, 
+                           name=name), 
+               type=type)
     if (!is.null(data)) ct[[type]] <- data
     list(ct)
 }
@@ -163,7 +170,7 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
       coordinateTransformations = list(
         list(
           scale = lapply(
-            axes,
+            unlist(axes),
             \(.) if(. == "c") 1 else s),
           type = "scale"
         )

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -14,7 +14,8 @@
 #' @param trans list of coordinate transformations; defaults to identity only.
 #' @param value character string (for one \code{region} and \code{_key}s), 
 #'   or vector (for many \code{region}s, \code{instances} and \code{regions}).
-#' @param ver character string; specifies the SpatialData version to comply with.
+#' @param ver character string; specifies the version of the SpatialData 
+#'   element to comply with.
 #' @param dim scalar integer in 2-4;
 #'   number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time) for image and 
 #'   label; when \code{type="image"}, C (channel) will be added (for any 

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -10,17 +10,17 @@
 #' 
 #' @param x element or list extracted from a OME-NGFF compliant .zattrs file.
 #' @param name character string for extraction (see ?base::`$`).
-#' @param type character string; either "array" (image/label) or "frame" (point/shape).
-#' @param label flag; when \code{type="frame"}, should attributes be for a label?
+#' @param type character string; either "image", "label", "point" or "shape"
 #' @param trans list of coordinate transformations; defaults to identity only.
 #' @param value character string (for one \code{region} and \code{_key}s), 
 #'   or vector (for many \code{region}s, \code{instances} and \code{regions}).
-#' @param ver character string; specifies the OME version to comply with.
+#' @param ver character string; specifies the SpatialData version to comply with.
 #' @param dim scalar integer in 2-4;
 #'   number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time); 
 #'   when \code{type="image"}, C (channel) will be added (for any \code{dim}).
 #' @param nch scalar integer; how many channels should there be?
-#'   (ignored unless \code{type="frame"} and \code{label=FALSE}). 
+#'   (ignored unless \code{type="shape"} or \code{type="point"}, and 
+#'   \code{label=FALSE}). 
 #' @param ... additional attributes (e.g., version, feature_key).
 #' 
 #' @details 
@@ -29,8 +29,8 @@
 #' \code{SingleCellExperiment}: \code{region}, \code{region/instance_key}.
 #' 
 #' When missing \code{x}, \code{SpatialDataAttrs} will generate a valid object 
-#' with default axes (array: cyx, frame: xy) and transformations (identify) 
-#' according to the specified type.
+#' with default axes (image/label: cyx, point/shape: xy) and transformations 
+#' (identify) according to the specified type.
 #' 
 #' @return character string
 #' 
@@ -55,27 +55,29 @@
 #' CTdata(z, "scale")
 #' 
 #' # constructor
-#' SpatialDataAttrs(type="frame")
+#' SpatialDataAttrs(type="point")
+#' SpatialDataAttrs(type="shape")
 #' SpatialDataAttrs(type="image", nch=7)
 #' SpatialDataAttrs(type="label", dim=3)
 #' 
 #' @export
-SpatialDataAttrs <- \(x, type=c("image", "label", "frame"), 
-    trans=NULL, ver="0.3", dim=2, nch=3, ...) 
+SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"), 
+    trans=NULL, ver=NULL, dim=2, nch=3, ...) 
 {
     stopifnot(
         length(dim) == 1, is.numeric(dim), dim %in% seq(2, 4),
         length(nch) == 1, is.numeric(nch), round(nch) == nch, nch > 0)
     if (!missing(x)) return(.SpatialDataAttrs(x))
     type <- match.arg(type)
-    ver <- .val_ome_ver(ver)
+    if(is.null(ver)) ver <- if(type == "point") "0.2" else "0.3"
+    ver <- .val_sd_ver(ver, type)
     ax <- .default_ax(type, dim)
     # transformations:
     ct <- trans %||% .default_ct(ax)
     # datasets:
     ds <- .default_ds(.ax_names(ax)) 
     # .zattrs list:
-    if (type != "frame") {
+    if (!type %in% c("point", "shape")) {
         # default structure
         res <- list()
         if(type != "label")
@@ -105,13 +107,15 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "frame"),
 }
 
 # Internal helper to generate OME-NGFF axes
-.default_ax <- \(type=c("image", "label", "frame"), dim=2) {
+.default_ax <- \(type=c("image", "label", "point", "shape"), dim=2) {
     c <- list(name="c", type="channel")
     t <- list(name="t", type="time")
     z <- list(name="z", type="space")
     y <- list(name="y", type="space")
     x <- list(name="x", type="space")
-    switch(match.arg(type), 
+    type <- match.arg(type)
+    type <- if(type %in% c("point", "shape")) "frame" else type
+    switch(type, 
         # xyzt for points/shapes
         frame={
             ax <- list(x$name, y$name)

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -16,10 +16,10 @@
 #'   or vector (for many \code{region}s, \code{instances} and \code{regions}).
 #' @param ver character string; specifies the version of the SpatialData 
 #'   element to comply with.
-#' @param dim scalar integer in 2-4;
+#' @param dim scalar integer in 2-4 when \code{type} is either "image" or 
+#'   "label", and 2-3 when "shape" or "point";
 #'   number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time) for image and 
-#'   label; when \code{type="image"}, C (channel) will be added (for any 
-#'   \code{dim}).
+#'   label; when \code{type="image"}).
 #' @param nch scalar integer; how many channels should there be?
 #'   (ignored if \code{type="label"}, \code{type="shape"}, or 
 #'   \code{type="point"}). 
@@ -119,7 +119,7 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
     y <- list(name="y", type="space")
     x <- list(name="x", type="space")
     switch(match.arg(type), 
-        # xyzt for points/shapes
+        # xyz for points/shapes
         point=,
         shape={
             ax <- list(x, y)

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -20,9 +20,8 @@
 #'   label; when \code{type="image"}, C (channel) will be added (for any 
 #'   \code{dim}).
 #' @param nch scalar integer; how many channels should there be?
-#'   (ignored unless \code{type="shape"} or \code{type="point"}, and 
-#'   \code{label=FALSE}). 
-#' @param ... additional attributes (e.g., version, feature_key).
+#'   (ignored if \code{type="label"}, \code{type="shape"}, or 
+#'   \code{type="point"}). 
 #' 
 #' @details 
 #' When \code{x} is a spatial element, the following applies:
@@ -30,10 +29,10 @@
 #' \code{SingleCellExperiment}: \code{region}, \code{region/instance_key}.
 #' 
 #' When missing \code{x}, \code{SpatialDataAttrs} will generate a valid object 
-#' with default axes (image: cyx, label:yx, point/shape: xy) and transformations 
-#' (identify) according to the specified type.
+#' with default axes (image: cyx, label: yx, point/shape: xy) and 
+#' transformations (identify) according to the specified type.
 #' 
-#' @return character string
+#' @return SpatialDataAttrs object
 #' 
 #' @examples
 #' x <- file.path("extdata", "blobs.zarr")
@@ -63,7 +62,7 @@
 #' 
 #' @export
 SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"), 
-    trans=NULL, ver=NULL, dim=2, nch=3, ...) 
+    trans=NULL, ver=NULL, dim=2, nch=3) 
 {
     if (!missing(x)) return(.SpatialDataAttrs(x))
     type <- match.arg(type)
@@ -76,10 +75,10 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
     ax <- .default_ax(type, dim)
     # transformations:
     ct <- trans %||% .default_ct(ax)
-    # datasets:
-    ds <- .default_ds(.ax_names(ax)) 
-    # .zattrs list:
+    # zarr attributes list:
     if (!type %in% c("point", "shape")) {
+        # datasets:
+        ds <- .default_ds(.ax_names(ax)) 
         # default structure
         res <- list()
         if(type != "label")
@@ -118,8 +117,7 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
     z <- list(name="z", type="space")
     y <- list(name="y", type="space")
     x <- list(name="x", type="space")
-    type <- match.arg(type)
-    switch(type, 
+    switch(match.arg(type), 
         # xyzt for points/shapes
         point=,
         shape={

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -114,10 +114,9 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "frame"),
     switch(match.arg(type), 
         # xyzt for points/shapes
         frame={
-            ax <- list(x, y)
+            ax <- list(x$name, y$name)
             if (dim > 2) {
-                ax <- c(ax, list(z))
-                if (dim > 3) ax <- c(ax, list(t))
+                ax <- c(ax, list(z$name))
             }
         },
         # tczyx for images/labels

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -16,8 +16,9 @@
 #'   or vector (for many \code{region}s, \code{instances} and \code{regions}).
 #' @param ver character string; specifies the SpatialData version to comply with.
 #' @param dim scalar integer in 2-4;
-#'   number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time); 
-#'   when \code{type="image"}, C (channel) will be added (for any \code{dim}).
+#'   number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time) for image and 
+#'   label; when \code{type="image"}, C (channel) will be added (for any 
+#'   \code{dim}).
 #' @param nch scalar integer; how many channels should there be?
 #'   (ignored unless \code{type="shape"} or \code{type="point"}, and 
 #'   \code{label=FALSE}). 
@@ -29,7 +30,7 @@
 #' \code{SingleCellExperiment}: \code{region}, \code{region/instance_key}.
 #' 
 #' When missing \code{x}, \code{SpatialDataAttrs} will generate a valid object 
-#' with default axes (image/label: cyx, point/shape: xy) and transformations 
+#' with default axes (image: cyx, label:yx, point/shape: xy) and transformations 
 #' (identify) according to the specified type.
 #' 
 #' @return character string
@@ -64,10 +65,11 @@
 SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"), 
     trans=NULL, ver=NULL, dim=2, nch=3, ...) 
 {
-    stopifnot(
-        length(dim) == 1, is.numeric(dim), dim %in% seq(2, 4),
-        length(nch) == 1, is.numeric(nch), round(nch) == nch, nch > 0)
     if (!missing(x)) return(.SpatialDataAttrs(x))
+    stopifnot(
+        length(dim) == 1, is.numeric(dim), 
+        dim %in% seq(2, if(type == "point") 3 else 4),
+        length(nch) == 1, is.numeric(nch), round(nch) == nch, nch > 0)
     type <- match.arg(type)
     if(is.null(ver)) ver <- if(type == "point") "0.2" else "0.3"
     ver <- .val_sd_ver(ver, type)
@@ -114,10 +116,10 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
     y <- list(name="y", type="space")
     x <- list(name="x", type="space")
     type <- match.arg(type)
-    type <- if(type %in% c("point", "shape")) "frame" else type
     switch(type, 
         # xyzt for points/shapes
-        frame={
+        point=,
+        shape={
             ax <- list(x$name, y$name)
             if (dim > 2) {
                 ax <- c(ax, list(z$name))

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -66,11 +66,11 @@ SpatialDataAttrs <- \(x, type=c("image", "label", "point", "shape"),
     trans=NULL, ver=NULL, dim=2, nch=3, ...) 
 {
     if (!missing(x)) return(.SpatialDataAttrs(x))
+    type <- match.arg(type)
     stopifnot(
         length(dim) == 1, is.numeric(dim), 
-        dim %in% seq(2, if(type == "point") 3 else 4),
+        dim %in% seq(2, if(type %in% c("point", "shape")) 3 else 4),
         length(nch) == 1, is.numeric(nch), round(nch) == nch, nch > 0)
-    type <- match.arg(type)
     if(is.null(ver)) ver <- if(type == "point") "0.2" else "0.3"
     ver <- .val_sd_ver(ver, type)
     ax <- .default_ax(type, dim)

--- a/R/sdFrame.R
+++ b/R/sdFrame.R
@@ -123,7 +123,7 @@ NULL
 #' @importFrom methods is
 #' @importFrom sf st_geometry_type
 #' @importFrom S4Vectors metadata<-
-SpatialDataPoint <- \(data=NULL, meta=SpatialDataAttrs(type="frame"), metadata=list(), ik=NULL, fk=NULL, ...) {
+SpatialDataPoint <- \(data=NULL, meta=SpatialDataAttrs(type="point"), metadata=list(), ik=NULL, fk=NULL, ...) {
     data <- .df_to_sf(data, "POINT")
     if (isTRUE(nrow(data) > 0L)) {
         gt <- tryCatch(unique(st_geometry_type(data)), error=\(.) "n/a")
@@ -153,7 +153,7 @@ SpatialDataPoint <- \(data=NULL, meta=SpatialDataAttrs(type="frame"), metadata=l
 #' @rdname SpatialDataFrame
 #' @importFrom methods is
 #' @importFrom S4Vectors metadata<-
-SpatialDataShape <- \(data=NULL, meta=SpatialDataAttrs(type="frame"), metadata=list(), ...) {
+SpatialDataShape <- \(data=NULL, meta=SpatialDataAttrs(type="shape"), metadata=list(), ...) {
     data <- .df_to_sf(data, "POLYGON")
     if (!is(data, "duckspatial_df")) 
         data <- .duck(data, "sdShape")

--- a/R/utils.R
+++ b/R/utils.R
@@ -175,7 +175,8 @@
 }
 
 # validate SpatialData version
-.val_sd_ver <- \(v, type) {
+.val_sd_ver <- \(v, type=c("image", "label", "point", "shape")) {
+  type <- match.arg(type)
   ok <- length(v) == 1 && 
     is.character(v) && 
     v %in% sprintf("0.%d", seq_len(if(type == "point") 2 else 3))

--- a/R/utils.R
+++ b/R/utils.R
@@ -174,6 +174,16 @@
     return(v)
 }
 
+# validate SpatialData version
+.val_sd_ver <- \(v, type) {
+  ok <- length(v) == 1 && 
+    is.character(v) && 
+    v %in% sprintf("0.%d", seq_len(if(type == "point") 2 else 3))
+  if (!ok) stop("invalid SpatialData 'version'; expected '0.x' where x is 1-3 ", 
+                "for image/label/shape and 1-2 for point")
+  return(v)
+}
+
 # multiscales ----
 
 # internal helper to get the 'active' metadata level

--- a/R/utils.R
+++ b/R/utils.R
@@ -175,8 +175,8 @@
 }
 
 # validate SpatialData version
-.val_sd_ver <- \(v, type=c("image", "label", "point", "shape")) {
-  type <- match.arg(type)
+.val_sd_ver <- \(v, type) {
+  type <- match.arg(type, c("image", "label", "point", "shape"))
   ok <- length(v) == 1 && 
     is.character(v) && 
     v %in% sprintf("0.%d", seq_len(if(type == "point") 2 else 3))

--- a/man/SpatialDataAttrs.Rd
+++ b/man/SpatialDataAttrs.Rd
@@ -38,9 +38,9 @@
 \usage{
 SpatialDataAttrs(
   x,
-  type = c("image", "label", "frame"),
+  type = c("image", "label", "point", "shape"),
   trans = NULL,
-  ver = "0.3",
+  ver = NULL,
   dim = 2,
   nch = 3,
   ...
@@ -89,18 +89,19 @@ SpatialDataAttrs(
 \arguments{
 \item{x}{element or list extracted from a OME-NGFF compliant .zattrs file.}
 
-\item{type}{character string; either "array" (image/label) or "frame" (point/shape).}
+\item{type}{character string; either "image", "label", "point" or "shape"}
 
 \item{trans}{list of coordinate transformations; defaults to identity only.}
 
-\item{ver}{character string; specifies the OME version to comply with.}
+\item{ver}{character string; specifies the SpatialData version to comply with.}
 
 \item{dim}{scalar integer in 2-4;
 number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time); 
 when \code{type="image"}, C (channel) will be added (for any \code{dim}).}
 
 \item{nch}{scalar integer; how many channels should there be?
-(ignored unless \code{type="frame"} and \code{label=FALSE}).}
+(ignored unless \code{type="shape"} or \code{type="point"}, and 
+\code{label=FALSE}).}
 
 \item{...}{additional attributes (e.g., version, feature_key).}
 
@@ -108,8 +109,6 @@ when \code{type="image"}, C (channel) will be added (for any \code{dim}).}
 
 \item{value}{character string (for one \code{region} and \code{_key}s), 
 or vector (for many \code{region}s, \code{instances} and \code{regions}).}
-
-\item{label}{flag; when \code{type="frame"}, should attributes be for a label?}
 }
 \value{
 character string
@@ -123,8 +122,8 @@ When \code{x} is a spatial element, the following applies:
 \code{SingleCellExperiment}: \code{region}, \code{region/instance_key}.
 
 When missing \code{x}, \code{SpatialDataAttrs} will generate a valid object 
-with default axes (array: cyx, frame: xy) and transformations (identify) 
-according to the specified type.
+with default axes (image/label: cyx, point/shape: xy) and transformations 
+(identify) according to the specified type.
 }
 \examples{
 x <- file.path("extdata", "blobs.zarr")
@@ -147,7 +146,8 @@ CTtype(z)
 CTdata(z, "scale")
 
 # constructor
-SpatialDataAttrs(type="frame")
+SpatialDataAttrs(type="point")
+SpatialDataAttrs(type="shape")
 SpatialDataAttrs(type="image", nch=7)
 SpatialDataAttrs(type="label", dim=3)
 

--- a/man/SpatialDataAttrs.Rd
+++ b/man/SpatialDataAttrs.Rd
@@ -95,7 +95,8 @@ SpatialDataAttrs(
 \item{ver}{character string; specifies the version of the SpatialData 
 element to comply with.}
 
-\item{dim}{scalar integer in 2-4;
+\item{dim}{scalar integer in 2-4 when \code{type} is either "image" or 
+"label", and 2-3 when "shape" or "point";
 number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time) for image and 
 label; when \code{type="image"}, C (channel) will be added (for any 
 \code{dim}).}

--- a/man/SpatialDataAttrs.Rd
+++ b/man/SpatialDataAttrs.Rd
@@ -42,8 +42,7 @@ SpatialDataAttrs(
   trans = NULL,
   ver = NULL,
   dim = 2,
-  nch = 3,
-  ...
+  nch = 3
 )
 
 \S4method{$}{SpatialDataAttrs}(x, name)
@@ -93,7 +92,8 @@ SpatialDataAttrs(
 
 \item{trans}{list of coordinate transformations; defaults to identity only.}
 
-\item{ver}{character string; specifies the SpatialData version to comply with.}
+\item{ver}{character string; specifies the version of the SpatialData 
+element to comply with.}
 
 \item{dim}{scalar integer in 2-4;
 number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time) for image and 
@@ -101,10 +101,8 @@ label; when \code{type="image"}, C (channel) will be added (for any
 \code{dim}).}
 
 \item{nch}{scalar integer; how many channels should there be?
-(ignored unless \code{type="shape"} or \code{type="point"}, and 
-\code{label=FALSE}).}
-
-\item{...}{additional attributes (e.g., version, feature_key).}
+(ignored if \code{type="label"}, \code{type="shape"}, or 
+\code{type="point"}).}
 
 \item{name}{character string for extraction (see ?base::`$`).}
 
@@ -112,7 +110,7 @@ label; when \code{type="image"}, C (channel) will be added (for any
 or vector (for many \code{region}s, \code{instances} and \code{regions}).}
 }
 \value{
-character string
+SpatialDataAttrs object
 }
 \description{
 The `SpatialDataAttrs` class
@@ -123,8 +121,8 @@ When \code{x} is a spatial element, the following applies:
 \code{SingleCellExperiment}: \code{region}, \code{region/instance_key}.
 
 When missing \code{x}, \code{SpatialDataAttrs} will generate a valid object 
-with default axes (image: cyx, label:yx, point/shape: xy) and transformations 
-(identify) according to the specified type.
+with default axes (image: cyx, label: yx, point/shape: xy) and 
+transformations (identify) according to the specified type.
 }
 \examples{
 x <- file.path("extdata", "blobs.zarr")

--- a/man/SpatialDataAttrs.Rd
+++ b/man/SpatialDataAttrs.Rd
@@ -96,8 +96,9 @@ SpatialDataAttrs(
 \item{ver}{character string; specifies the SpatialData version to comply with.}
 
 \item{dim}{scalar integer in 2-4;
-number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time); 
-when \code{type="image"}, C (channel) will be added (for any \code{dim}).}
+number of dimensions: 2 = XY, 3 adds Z, 4 adds T (time) for image and 
+label; when \code{type="image"}, C (channel) will be added (for any 
+\code{dim}).}
 
 \item{nch}{scalar integer; how many channels should there be?
 (ignored unless \code{type="shape"} or \code{type="point"}, and 
@@ -122,7 +123,7 @@ When \code{x} is a spatial element, the following applies:
 \code{SingleCellExperiment}: \code{region}, \code{region/instance_key}.
 
 When missing \code{x}, \code{SpatialDataAttrs} will generate a valid object 
-with default axes (image/label: cyx, point/shape: xy) and transformations 
+with default axes (image: cyx, label:yx, point/shape: xy) and transformations 
 (identify) according to the specified type.
 }
 \examples{

--- a/man/SpatialDataFrame.Rd
+++ b/man/SpatialDataFrame.Rd
@@ -23,7 +23,7 @@
 \usage{
 SpatialDataPoint(
   data = NULL,
-  meta = SpatialDataAttrs(type = "frame"),
+  meta = SpatialDataAttrs(type = "point"),
   metadata = list(),
   ik = NULL,
   fk = NULL,
@@ -32,7 +32,7 @@ SpatialDataPoint(
 
 SpatialDataShape(
   data = NULL,
-  meta = SpatialDataAttrs(type = "frame"),
+  meta = SpatialDataAttrs(type = "shape"),
   metadata = list(),
   ...
 )

--- a/tests/testthat/test-ctutils.R
+++ b/tests/testthat/test-ctutils.R
@@ -21,6 +21,18 @@ test_that("axes", {
         expect_length(z, d)
         expect_in(z, c("time","channel","space"))
     }
+    es <- list(shape(x), point(x))
+    for (e in es) {
+        z <- axes(e)
+        d <- length(dim(e))
+        expect_type(z, "list")
+        expect_length(z, d)
+        expect_error(axes(e, "bad"))
+        # name
+        # TODO: should "name" only return itself for frames, or return error
+        expect_silent(z <- axes(e, "name"))
+        expect_type(z, "character")
+    }
 })
 
 .CTtype <- c(

--- a/tests/testthat/test-sdattrs.R
+++ b/tests/testthat/test-sdattrs.R
@@ -63,16 +63,18 @@ test_that(".val_ome_ver()", {
 })
 test_that(".val_sd_ver()", {
     # invalid
-    expect_error(.val_sd_ver(1))
-    expect_error(.val_sd_ver(TRUE))
-    expect_error(.val_sd_ver("0.0"))
-    expect_error(.val_sd_ver("0.30"))
-    expect_error(.val_sd_ver(c("0.3", "0.4")))
+    expect_error(.val_sd_ver(0.3), 'argument "type" is missing')
+    expect_error(.val_sd_ver(1, "image"))
+    expect_error(.val_sd_ver(TRUE, "image"))
+    expect_error(.val_sd_ver("0.0", "image"))
+    expect_error(.val_sd_ver("0.30", "image"))
+    expect_error(.val_sd_ver(c("0.3", "0.4"), "image"))
     expect_error(.val_sd_ver("0.3", "point"))
     # valid
     expect_silent(x <- .val_sd_ver(v <- "0.3", "image"))
     expect_silent(x <- .val_sd_ver(v <- "0.3", "label"))
     expect_silent(x <- .val_sd_ver(v <- "0.3", "shape"))
+    expect_silent(x <- .val_sd_ver(v <- "0.2", "point"))
     expect_type(x, "character")
     expect_length(x, 1)
     expect_identical(x, v)
@@ -105,6 +107,8 @@ test_that("SpatialDataAttrs()", {
         expect_length(y, 7)
         expect_type(y, "character")
         expect_all_true(!duplicated(y))
+        # version
+        expect_equal(x$spatialdata_attrs$version, "0.3")
     }
     # 2-4D label
     for (d in seq(2, 4)) {
@@ -113,19 +117,28 @@ test_that("SpatialDataAttrs()", {
         expect_length(y, d)
         expect_equal(sum(y == "time"), ifelse(d == 4, 1, 0))
         expect_equal(sum(y == "space"), ifelse(d == 2, 2, 3))
+        # version
+        expect_equal(x$spatialdata_attrs$version, "0.3")
     }
     # 3-4D shape/point
+    nms <- c("x", "y", "z")
     for (d in seq(2, 3)) {
       for(typ in c("shape", "point")){
         x <- SpatialDataAttrs(type=typ, dim=d)
+        ok <- if (d == 2) nms[-3] else nms
         y <- axes(x)
         expect_length(y, d)
-        xy <- c("x", "y")
-        expect_equal(unlist(y), if(d == 2) xy else c(xy, "z"))
+        expect_equal(unlist(y), ok)
         expect_null(channels(x))
-        # TODO: should we return x itself, regardless of requested name?
-        expect_error(axes(x, "name"))
+        # axes name
+        y <- axes(x, "name")
+        expect_length(y, d)
+        expect_type(y, "character")
+        expect_identical(y, ok)
         expect_error(axes(x, "type")) 
+        # version
+        expect_equal(x$spatialdata_attrs$version, 
+                     if(typ == "point") "0.2" else "0.3")
       }
     }
 })

--- a/tests/testthat/test-sdattrs.R
+++ b/tests/testthat/test-sdattrs.R
@@ -61,6 +61,23 @@ test_that(".val_ome_ver()", {
     expect_length(x, 1)
     expect_identical(x, v)
 })
+test_that(".val_sd_ver()", {
+  # invalid
+  expect_error(.val_sd_ver(1))
+  expect_error(.val_sd_ver(TRUE))
+  expect_error(.val_sd_ver("0.0"))
+  expect_error(.val_sd_ver("0.30"))
+  expect_error(.val_sd_ver(c("0.3", "0.4")))
+  expect_error(.val_sd_ver(v <- "0.3-x"))
+  expect_error(.val_sd_ver("0.3", "point"))
+  # valid
+  expect_silent(x <- .val_sd_ver(v <- "0.3", "image"))
+  expect_silent(x <- .val_sd_ver(v <- "0.3", "label"))
+  expect_silent(x <- .val_sd_ver(v <- "0.3", "shape"))
+  expect_type(x, "character")
+  expect_length(x, 1)
+  expect_identical(x, v)
+})
 test_that("SpatialDataAttrs()", {
     # invalid
     expect_error(SpatialDataAttrs(nch=0))
@@ -98,7 +115,8 @@ test_that("SpatialDataAttrs()", {
     }
     # 3-4D shape/point
     for (d in seq(2, 3)) {
-        x <- SpatialDataAttrs(type="frame", dim=d)
+      for(t in c("shape", "point")){
+        x <- SpatialDataAttrs(type=t, dim=d)
         y <- axes(x)
         expect_length(y, d)
         xy <- c("x", "y")
@@ -106,6 +124,7 @@ test_that("SpatialDataAttrs()", {
         expect_null(channels(x))
         # TODO: should we return x itself, regardless of requested name?
         expect_error(axes(x, "name"))
-        expect_error(axes(x, "type"))
+        expect_error(axes(x, "type")) 
+      }
     }
 })

--- a/tests/testthat/test-sdattrs.R
+++ b/tests/testthat/test-sdattrs.R
@@ -97,12 +97,15 @@ test_that("SpatialDataAttrs()", {
         expect_equal(sum(y == "space"), ifelse(d == 2, 2, 3))
     }
     # 3-4D shape/point
-    for (d in seq(2, 4)) {
+    for (d in seq(2, 3)) {
         x <- SpatialDataAttrs(type="frame", dim=d)
-        y <- axes(x, "type")
+        y <- axes(x)
         expect_length(y, d)
+        xy <- c("x", "y")
+        expect_equal(unlist(y), if(d == 2) xy else c(xy, "z"))
         expect_null(channels(x))
-        expect_equal(sum(y == "time"), ifelse(d == 4, 1, 0))
-        expect_equal(sum(y == "space"), ifelse(d == 2, 2, 3))
+        # TODO: should we return x itself, regardless of requested name?
+        expect_error(axes(x, "name"))
+        expect_error(axes(x, "type"))
     }
 })

--- a/tests/testthat/test-sdattrs.R
+++ b/tests/testthat/test-sdattrs.R
@@ -62,21 +62,20 @@ test_that(".val_ome_ver()", {
     expect_identical(x, v)
 })
 test_that(".val_sd_ver()", {
-  # invalid
-  expect_error(.val_sd_ver(1))
-  expect_error(.val_sd_ver(TRUE))
-  expect_error(.val_sd_ver("0.0"))
-  expect_error(.val_sd_ver("0.30"))
-  expect_error(.val_sd_ver(c("0.3", "0.4")))
-  expect_error(.val_sd_ver(v <- "0.3-x"))
-  expect_error(.val_sd_ver("0.3", "point"))
-  # valid
-  expect_silent(x <- .val_sd_ver(v <- "0.3", "image"))
-  expect_silent(x <- .val_sd_ver(v <- "0.3", "label"))
-  expect_silent(x <- .val_sd_ver(v <- "0.3", "shape"))
-  expect_type(x, "character")
-  expect_length(x, 1)
-  expect_identical(x, v)
+    # invalid
+    expect_error(.val_sd_ver(1))
+    expect_error(.val_sd_ver(TRUE))
+    expect_error(.val_sd_ver("0.0"))
+    expect_error(.val_sd_ver("0.30"))
+    expect_error(.val_sd_ver(c("0.3", "0.4")))
+    expect_error(.val_sd_ver("0.3", "point"))
+    # valid
+    expect_silent(x <- .val_sd_ver(v <- "0.3", "image"))
+    expect_silent(x <- .val_sd_ver(v <- "0.3", "label"))
+    expect_silent(x <- .val_sd_ver(v <- "0.3", "shape"))
+    expect_type(x, "character")
+    expect_length(x, 1)
+    expect_identical(x, v)
 })
 test_that("SpatialDataAttrs()", {
     # invalid
@@ -85,6 +84,7 @@ test_that("SpatialDataAttrs()", {
     expect_error(SpatialDataAttrs(ver="0.0"))
     expect_error(SpatialDataAttrs(type="bad"))
     expect_error(SpatialDataAttrs(type = "point", dim=4))
+    expect_error(SpatialDataAttrs(type = "shape", dim=4))
     # 2-4D image
     nms <- c("c", "t", "z", "y", "x")
     for (d in seq(2, 4)) {

--- a/tests/testthat/test-sdattrs.R
+++ b/tests/testthat/test-sdattrs.R
@@ -84,6 +84,7 @@ test_that("SpatialDataAttrs()", {
     expect_error(SpatialDataAttrs(dim=7))
     expect_error(SpatialDataAttrs(ver="0.0"))
     expect_error(SpatialDataAttrs(type="bad"))
+    expect_error(SpatialDataAttrs(type = "point", dim=4))
     # 2-4D image
     nms <- c("c", "t", "z", "y", "x")
     for (d in seq(2, 4)) {
@@ -115,8 +116,8 @@ test_that("SpatialDataAttrs()", {
     }
     # 3-4D shape/point
     for (d in seq(2, 3)) {
-      for(t in c("shape", "point")){
-        x <- SpatialDataAttrs(type=t, dim=d)
+      for(typ in c("shape", "point")){
+        x <- SpatialDataAttrs(type=typ, dim=d)
         y <- axes(x)
         expect_length(y, d)
         xy <- c("x", "y")


### PR DESCRIPTION
Related to #239. 

Fixes created shape/point metadata. 
* axes metadata does only have space dimensions, thus does not have `name` or `type`.
* point version is 0.2 but label/image/shape are 0.3. See:
   https://github.com/scverse/spatialdata/blob/main/src/spatialdata/_io/format.py
* fix coordinate transformations input and output axes entries. 